### PR TITLE
Feat: 헤더에서 로고와 데이터룸을 눌렀을 때 새로고침되게 구현

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -228,7 +228,7 @@ const Header = () => {
       {isMobile ? ( //mobile
         <HeaderStyle>
           <div className="header">
-            <Link to="/">
+            <Link to="/" reloadDocument={true}>
               <MovLogoButton>
                 <img src={logo} style={movimagestyle} className="App-logo" />
                 polar
@@ -292,7 +292,7 @@ const Header = () => {
                 >
                   <MovSuggestionButton>건의사항</MovSuggestionButton>
                 </a>
-                <Link to="/data-room">
+                <Link to="/data-room" reloadDocument={true}>
                   <MovDataRoomButton>데이터룸</MovDataRoomButton>
                 </Link>
               </div>
@@ -313,7 +313,7 @@ const Header = () => {
         //pc
         <HeaderStyle>
           <div className="header">
-            <Link to="/">
+            <Link to="/" reloadDocument={true}>
               <LogoButton>
                 <img src={logo} style={imagestyle} className="App-logo" />
                 polar
@@ -379,7 +379,7 @@ const Header = () => {
                 >
                   <SuggestionButton>건의사항</SuggestionButton>
                 </a>
-                <Link to="/data-room">
+                <Link to="/data-room" reloadDocument={true}>
                   <DataRoomButton>데이터룸</DataRoomButton>
                 </Link>
               </div>


### PR DESCRIPTION
구글 폼에 올라온 버그 리포트 중 하나입니다

데이터 룸이나 메인에 있을 때 다시 로고, 데이터룸을 클릭해도 현재 페이지에서 새로고침이 안되는 문제를 해결했습니다

간단하게 reload라는 Prop를 주면 됐습니다(찾는데는 조금 걸렸네요;;)